### PR TITLE
feat: 収入利用率50%超過時の警告バナーを実装

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -29,6 +29,21 @@
     </div>
   <% end %>
 
+  <%# 警告バナー（収入利用率50%超） %>
+  <% if @calc.income_set? && @calc.over_budget? %>
+    <div class="flex items-center gap-4 rounded-2xl bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/20 px-5 py-4">
+      <div class="w-9 h-9 rounded-xl bg-red-100 dark:bg-red-500/20 flex items-center justify-center shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+        </svg>
+      </div>
+      <div class="flex-1">
+        <p class="text-sm font-bold text-red-700 dark:text-red-400">固定費が収入の<span class="text-base"><%= @calc.usage_rate %>%</span>を占めています</p>
+        <p class="text-xs text-red-600/70 dark:text-red-400/70 mt-0.5">収入の50%を超えています。固定費の見直しを検討してください。</p>
+      </div>
+    </div>
+  <% end %>
+
   <%# ヒーローカード 2枚 %>
   <div class="grid gap-4 lg:grid-cols-2">
 
@@ -91,21 +106,6 @@
     </div>
 
   </div>
-
-  <%# 警告バナー（収入利用率50%超） %>
-  <% if @calc.income_set? && @calc.over_budget? %>
-    <div class="flex items-center gap-4 rounded-2xl bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/20 px-5 py-4">
-      <div class="w-9 h-9 rounded-xl bg-red-100 dark:bg-red-500/20 flex items-center justify-center shrink-0">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
-        </svg>
-      </div>
-      <div class="flex-1">
-        <p class="text-sm font-bold text-red-700 dark:text-red-400">固定費が収入の<span class="text-base"><%= @calc.usage_rate %>%</span>を占めています</p>
-        <p class="text-xs text-red-600/70 dark:text-red-400/70 mt-0.5">収入の50%を超えています。固定費の見直しを検討してください。</p>
-      </div>
-    </div>
-  <% end %>
 
   <%# 2カラムカード %>
   <div class="grid gap-4 lg:grid-cols-3">


### PR DESCRIPTION
### タスク
- [x] 収入利用率の計算（fixed_cost_amount合計 ÷ monthly_income × 100）
- [x] 50%超えで警告バナーを表示
- [x] バナーのスタイリング（赤背景・警告アイコン）

close #27 